### PR TITLE
Add ability to make an empty table with Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,15 @@ recreate-db:
 	@sleep 2  # Wait for PostgreSQL to start
 	@make setup-db
 
+empty:
+	@docker-compose down
+	@docker-compose up -d
+	@sleep 2  # Wait for PostgreSQL to start
+	@make setup-empty-db
+
 setup-db: create-tables create-views insert-data
+
+setup-empty-db: create-tables create-views
 
 create-tables:
 	@cat ${CORE_SCHEMA} ${OP_SCHEMA} ${POP_SCHEMA} | docker exec -i ${PG_CONTAINER_NAME} psql -U ${PG_USER} -d ${PG_DATABASE}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ To create a test database with simple sample data:
 $ make
 ```
 
+It is also possible to make an empty database for testing:
+
+```
+$ make empty
+```
+
 Note that the database username and password are hard-coded directly in
 the docker-compose file, as it's only meant for testing. Also, the
 database will be mounted to `$HOME/postgres_data`.


### PR DESCRIPTION
Add "make empty" option to makefile, this helps with testing against hapi-pipelines.