### PR TITLE
Add missing p-codes for admin1 and admin2 in OP and POP views.

### DIFF
--- a/sql/views/hapi-core-views.sql
+++ b/sql/views/hapi-core-views.sql
@@ -54,6 +54,7 @@ DROP VIEW IF EXISTS admin2_view;
 
 CREATE VIEW admin2_view AS
 SELECT ADM2.*,
+       ADM1.code AS admin1_code,
        ADM1.name AS admin1_name,
        ADM1.is_unspecified AS admin1_is_unspecified,
        ADM1.reference_period_start AS admin1_reference_period_start,

--- a/sql/views/hapi-core-views.sql
+++ b/sql/views/hapi-core-views.sql
@@ -19,6 +19,8 @@ DROP VIEW IF EXISTS resource_view;
 
 CREATE VIEW resource_view AS
 SELECT R.*,
+       D.hdx_id AS dataset_hdx_id,
+       D.hdx_stub AS dataset_hdx_stub,
        D.title AS dataset_title,
        D.provider_code AS dataset_provider_code,
        D.provider_name AS dataset_provider_name

--- a/sql/views/hapi-op-view.sql
+++ b/sql/views/hapi-op-view.sql
@@ -25,8 +25,10 @@ SELECT OP.*,
        S.name AS sector_name,
        LOC.code AS location_code,
        LOC.name AS location_name,
+       ADM1.code AS admin1_code,
        ADM1.name AS admin1_name,
        ADM1.is_unspecified AS admin1_is_unspecified,
+       ADM2.code AS admin2_code,
        ADM2.name AS admin2_name,
        ADM2.is_unspecified AS admin2_is_unspecified
 FROM operational_presence OP

--- a/sql/views/hapi-pop-view.sql
+++ b/sql/views/hapi-pop-view.sql
@@ -19,12 +19,14 @@ SELECT POP.*,
        R.filename AS resource_filename,
        R.update_date AS resource_update_date,
        G.description AS gender_description,
-       ADM2.name AS admin2_name,
-       ADM2.is_unspecified AS admin2_is_unspecified,
+       LOC.code AS location_code,
+       LOC.name AS location_name,
+       ADM1.code AS admin1_code,
        ADM1.name AS admin1_name,
        ADM1.is_unspecified AS admin1_is_unspecified,
-       LOC.code AS location_code,
-       LOC.name AS location_name
+       ADM2.code AS admin2_code,
+       ADM2.name AS admin2_name,
+       ADM2.is_unspecified AS admin2_is_unspecified
 FROM population POP
 LEFT JOIN resource R ON POP.resource_ref=R.id
 LEFT JOIN dataset D ON R.dataset_ref=D.id


### PR DESCRIPTION
The views for 3W and population were missing P-codes for admin1 and admin2. This correction adds them in.

Note that we'll have to synchronise this change with SQLAlchemy.